### PR TITLE
[FIX] show visible but disabled owner of windows, that are behind some child window

### DIFF
--- a/Core/AppWindow.cs
+++ b/Core/AppWindow.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Switcheroo - The incremental-search task switcher for Windows.
  * http://www.switcheroo.io/
  * Copyright 2009, 2010 James Sulak
@@ -179,7 +179,7 @@ namespace Switcheroo.Core
 
         private bool IsOwnerOrOwnerNotVisible()
         {
-            return Owner == null || !Owner.Visible;
+            return Owner == null || !(Owner.Visible && Owner.Enabled);
         }
 
         private bool HasITaskListDeletedProperty()


### PR DESCRIPTION
Eg. Total Commander has some child windows with: 
 - ExStyle: WINDOWEDGE | CONTROLPARENT
 - Style: OVERLAPPEDWINDOW | MAXIMIZE | CLIPCHILDREN | CLIPSIBLINGS | VISIBLE
and while such a window is open Swicheroo doesn't show neither the AppWindow nor the child window.